### PR TITLE
Fix Node execSync and shell

### DIFF
--- a/crawler_blocker.js
+++ b/crawler_blocker.js
@@ -13,7 +13,8 @@ const log = (message) => {
 
 const runCommand = (command) => {
     try {
-        execSync(command, { stdio: 'inherit' });
+        // Use a shell so that redirection operators work correctly
+        execSync(command, { stdio: 'inherit', shell: '/bin/sh' });
         log(`Successfully ran command: ${command}`);
     } catch (error) {
         log(`Command failed: ${command} - ${error.message}`);


### PR DESCRIPTION
- fix `execSync` usage in Node.js script
- `node --check crawler_blocker.js`